### PR TITLE
Handle time signature events.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = tab
+indent_size = 2

--- a/dist/MIDIEvents.js
+++ b/dist/MIDIEvents.js
@@ -215,11 +215,14 @@ MIDIEvents.createParser=function(stream, startAt, strictMode) {
 							}
 							return event;
 							break;
-						 // Not implemented
 						case MIDIEvents.EVENT_META_TIME_SIGNATURE:
 							if(strictMode&&4!==event.length)
 								throw new Error(stream.pos()+' Bad metaevent length.');
 							event.data=stream.readBytes(event.length);
+							event.param1=event.data[0];
+							event.param2=event.data[1];
+							event.param3=event.data[2];
+							event.param4=event.data[3];
 							return event;
 							break;
 						case MIDIEvents.EVENT_META_SEQUENCER_SPECIFIC:

--- a/src/MIDIEvents.js
+++ b/src/MIDIEvents.js
@@ -214,11 +214,14 @@ MIDIEvents.createParser=function(stream, startAt, strictMode) {
 							}
 							return event;
 							break;
-						 // Not implemented
 						case MIDIEvents.EVENT_META_TIME_SIGNATURE:
 							if(strictMode&&4!==event.length)
 								throw new Error(stream.pos()+' Bad metaevent length.');
 							event.data=stream.readBytes(event.length);
+							event.param1=event.data[0];
+							event.param2=event.data[1];
+							event.param3=event.data[2];
+							event.param4=event.data[3];
 							return event;
 							break;
 						case MIDIEvents.EVENT_META_SEQUENCER_SPECIFIC:

--- a/tests/midievents.mocha.js
+++ b/tests/midievents.mocha.js
@@ -105,6 +105,22 @@ describe('Reading well formed MIDI events', function(){
 		assert.equal(events[13].delta,0x00);
 	});
 
+	it("Should parse time signature", function() {
+		var event, events=[], parser;
+	  parser=new MIDIEvents.createParser(
+		  new DataView(new Uint8Array([0x00, 0xFF, 0x58, 0x04, 0x04, 0x02, 0x08, 0x08]).buffer),
+		    0, false);
+	  event=parser.next();
+
+		assert.equal(event.type,MIDIEvents.EVENT_META);
+		assert.equal(event.subtype,MIDIEvents.EVENT_META_TIME_SIGNATURE);
+		assert.equal(event.index,0);
+		assert.equal(event.param1,4);
+		assert.equal(event.param2,2);
+		assert.equal(event.param3,8);
+		assert.equal(event.param4,8);
+	});
+
   // TO DO : report MIDIEvents specific MIDIFile tests here
 
 });


### PR DESCRIPTION
They are not thoroughly tested. At first, I try to investigate why it handles time wrong and solve by detecting time signature events, but it turns out to be a bug in the DAW software.
