### PR TITLE
Remove unused readInt32

### DIFF
--- a/src/midievents.js
+++ b/src/midievents.js
@@ -76,11 +76,6 @@ MIDIEvents.createParser = function midiEventsCreateParser(
         this.position = this.position + 2;
         return v;
       },
-      readUint32: function() {
-        var v = this.buffer.getUint16(this.position);
-        this.position = this.position + 2;
-        return v;
-      },
       readVarInt: function() {
         var v = 0;
         var i = 0;


### PR DESCRIPTION
This function seems to have a bug. It's not used, so let's remove it.


<!-- Check the boxes with a `x` like so `[x]` -->

### Code quality
- [ ] I made some tests for my changes
- [ ] I added my name in the
 [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
 field of the package.json file

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license

<!--

If you already maintain several NPM modules / NodeJS
 project, making significant changes on one of my modules
 automatically legitimates you as a core developer.

This is because i could die or even not give a shit to
 this project someday and i don't want people to get
 stuck.

If you want to help, fill the following with to get
GitHub/NPM r/w access.

-->
### Join
- [x] I wish to join the core team
- [x] I agree that with great powers comes responsibilities
- [x] I'm a nice person

My NPM username:
mmontag